### PR TITLE
grain weights are not being saved from recipe form

### DIFF
--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -2,10 +2,15 @@ class RecipesController < ApplicationController
 
   def new
     @recipe = Recipe.new
+    3.times { @recipe.grains.build }
   end
 
   def create
     @recipe = current_user.recipes.create(recipe_params)
+    @recipe.grains.each do |grain|
+      grain.weight.to_f
+      grain.save
+    end
     if @recipe.save
       flash[:notice] = "Recipe saved."
       redirect_to @recipe
@@ -22,6 +27,6 @@ class RecipesController < ApplicationController
   private
 
   def recipe_params
-    params.require(:recipe).permit(:name, :style, :yeast, :summary, :notes)
+    params.require(:recipe).permit(:name, :style, :grains, :yeast, :summary, :notes)
   end
 end

--- a/app/controllers/recipes_controller.rb
+++ b/app/controllers/recipes_controller.rb
@@ -7,10 +7,6 @@ class RecipesController < ApplicationController
 
   def create
     @recipe = current_user.recipes.create(recipe_params)
-    @recipe.grains.each do |grain|
-      grain.weight.to_f
-      grain.save
-    end
     if @recipe.save
       flash[:notice] = "Recipe saved."
       redirect_to @recipe
@@ -27,6 +23,6 @@ class RecipesController < ApplicationController
   private
 
   def recipe_params
-    params.require(:recipe).permit(:name, :style, :grains, :yeast, :summary, :notes)
+    params.require(:recipe).permit(:name, :style, :yeast, :summary, :notes, grains_attributes: [:name, :weight])
   end
 end

--- a/app/views/recipes/new.html.haml
+++ b/app/views/recipes/new.html.haml
@@ -4,6 +4,11 @@
   = form.text_field :name, autofocus: true, placeholder: 'Name'
   = form.text_field :style, autofocus: true, placeholder: 'Style'
   = form.text_field :yeast, autofocus: true, placeholder: 'Yeast'
+  = form.fields_for :grains do |grain_fields|
+    = grain_fields.label :name, "Grain #{grain_fields.index + 1} name"
+    = grain_fields.text_field :name
+    = grain_fields.label :weight, "Grain #{grain_fields.index + 1} weight"
+    = grain_fields.number_field :weight
   = form.text_field :summary, autofocus: true, placeholder: 'Summary'
   = form.text_field :notes, autofocus: true, placeholder: 'Notes'
   = form.submit 'Save Recipe'

--- a/app/views/recipes/show.html.haml
+++ b/app/views/recipes/show.html.haml
@@ -5,3 +5,7 @@
 = @recipe.yeast
 = @recipe.summary
 = @recipe.notes
+- @recipe.grains.each do |grain|
+  %p
+    = grain.name
+    = grain.weight

--- a/spec/features/user_creates_recipes_spec.rb
+++ b/spec/features/user_creates_recipes_spec.rb
@@ -21,7 +21,8 @@ feature "User creates recipes", :type => :feature do
 
     click_button "Save Recipe"
 
-    expect(current_path).to eq recipe_path(id: Recipe.first)
+    expect(Recipe.count).to eq(1)
+    expect(current_path).to eq recipe_path(Recipe.first)
     expect(page).to have_content("Black Stout")
     expect(page).to have_content("Nottingham")
     expect(page).to have_content("2-row")

--- a/spec/features/user_creates_recipes_spec.rb
+++ b/spec/features/user_creates_recipes_spec.rb
@@ -12,6 +12,10 @@ feature "User creates recipes", :type => :feature do
     fill_in "Name", with: "Black Stout"
     fill_in "Style", with: "Stout"
     fill_in "Yeast", with: "Nottingham"
+    fill_in "Grain 1 name", with: "2-row"
+    fill_in "Grain 1 weight", with: "10"
+    fill_in "Grain 2 name", with: "Crystal 40L"
+    fill_in "Grain 2 weight", with: "2.25" 
     fill_in "Summary", with: "A very dark stout"
     fill_in "Notes", with: "Brew very carefully..."
 
@@ -20,6 +24,10 @@ feature "User creates recipes", :type => :feature do
     expect(current_path).to eq recipe_path(id: Recipe.first)
     expect(page).to have_content("Black Stout")
     expect(page).to have_content("Nottingham")
+    expect(page).to have_content("2-row")
+    expect(page).to have_content("10")
+    expect(page).to have_content("Crystal 40L")
+    expect(page).to have_content("2.25")
     expect(page).to have_content("A very dark stout")
     expect(page).to have_content("Black Stout")
     expect(page).to have_content("Brew very carefully...")
@@ -34,6 +42,7 @@ feature "User creates recipes", :type => :feature do
 
     expect(current_path).to eq new_recipe_path
     expect(page).to have_content("Name can't be blank")
+    expect(page).to have_content("Must include at least one grain")
   end
 
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -8,11 +8,13 @@ describe Recipe do
 
   context "associations" do
     it { expect(@recipe).to belong_to(:user) }
+    it { expect(@recipe).to have_many(:grains) }
   end
 
   context "validations" do
     it { expect(@recipe).to validate_presence_of(:name) }
     it { expect(@recipe).to validate_presence_of(:user_id) }
+    it { expect(@recipe).to validate_presence_of(:grains) }
   end
 
 end


### PR DESCRIPTION
When I run the feature spec `/spec/features/user_creates_recipes_spec.rb`, I get this error:

```
Failure/Error: expect(current_path).to eq recipe_path(id: Recipe.first)
     ActionController::UrlGenerationError:
       No route matches {:action=>"show", :controller=>"recipes", :id=>nil} missing required keys: [:id]
```

And when I visit `recipes/new` in my browser and enter in values for the required fields [recipe name, grain names, grain weights] I get an error that the record can't be saved without grains:
`There was an error saving your recipe: Grains can't be blank`

I assumed that this was because the grains were being saved as strings instead of numbers (which is why I added the loop at line 10 in the recipe controller), but I can't tell if this is the case. In the console, when I enter a string number as the weight and try to save it, it's saved successfully (it's somehow automatically converted to a number):

```
> r.grains.new(name: "grain", weight: "1")
=> #<Grain id: nil, name: "grain", weight: #<BigDecimal:7fde3290f7c8,'0.1E1',9(18)>, created_at: nil, updated_at: nil, recipe_id: nil>
> r.save
   (0.2ms)  begin transaction
  SQL (0.5ms)  INSERT INTO "recipes" ("name", "user_id", "created_at", "updated_at") VALUES (?, ?, ?, ?)  [["name", "beers"], ["user_id", 1], ["created_at", "2015-01-26 23:47:54.831762"], ["updated_at", "2015-01-26 23:47:54.831762"]]
  SQL (0.1ms)  INSERT INTO "grains" ("name", "weight", "recipe_id", "created_at", "updated_at") VALUES (?, ?, ?, ?, ?)  [["name", "grain"], ["weight", 1.0], ["recipe_id", 12], ["created_at", "2015-01-26 23:47:54.834927"], ["updated_at", "2015-01-26 23:47:54.834927"]]
   (0.8ms)  commit transaction
=> true
```

Any idea what's going on here?
