### PR TITLE
original gravity calculation on recipe#show

### DIFF
--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -43,11 +43,7 @@ class Recipe < ActiveRecord::Base
   end
 
   def total_grain_weight
-    total_weight = 0
-    grains.each do |grain|
-      total_weight += grain.weight
-    end
-    total_weight
+    grains.sum(:weight)
   end
 
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -35,4 +35,19 @@ class Recipe < ActiveRecord::Base
   validates_presence_of :grains,  message: "must include name and weight of at least one grain"
   validates_presence_of :hops,  message: "must include name and weight of at least one hop"
   
+
+  def original_gravity
+    brewhouse_efficiency = 0.75
+    batch_size = 5
+    (((37 * brewhouse_efficiency) / (batch_size / total_grain_weight)) + 1000) / 1000
+  end
+
+  def total_grain_weight
+    total_weight = 0
+    grains.each do |grain|
+      total_weight += grain.weight
+    end
+    total_weight
+  end
+
 end

--- a/app/views/recipes/show.html.haml
+++ b/app/views/recipes/show.html.haml
@@ -7,6 +7,7 @@
   %p
     = yeast.name
     = yeast.attenuation
+%p Original Gravity: #{'%.3f' % @recipe.original_gravity}
 %p Summary: #{@recipe.summary}
 %p Grains:
 - @recipe.grains.each do |grain|

--- a/spec/factories/recipe.rb
+++ b/spec/factories/recipe.rb
@@ -2,6 +2,7 @@ FactoryGirl.define do
   factory :recipe do
     name "Name"
     style "Style"
+    batch_size 2.5
 
     before(:create) do |recipe, yeast|
       yeasts_attributes = []

--- a/spec/features/user_creates_recipes_spec.rb
+++ b/spec/features/user_creates_recipes_spec.rb
@@ -37,6 +37,7 @@ expect(page).to have_content("Black Stout")
     expect(page).to have_content("1.5")
     expect(page).to have_content("A very dark stout")
     expect(page).to have_content("Brew very carefully...")
+    expect(page).to have_content("1.068")
     expect(page).to have_content("Recipe saved.")
   end
 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -28,4 +28,16 @@ describe Recipe do
     end
   end
 
+  context "#total_grain_weight" do
+    it "should calculate the total grain weight" do
+      recipe = create(:recipe)
+      recipe.grains.destroy_all
+      recipe.grains.build(name: "2-row", weight: 10)
+      recipe.grains.build(name: "Black Patent", weight: 2.5)
+      recipe.save
+
+      expect(recipe.total_grain_weight).to eq(12.5)
+    end
+  end
+
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -19,4 +19,13 @@ describe Recipe do
     it { expect(@recipe.batch_size).to_not be_nil }
   end
 
+  context "#original_gravity" do
+
+    it "should calculate the original gravity" do
+      recipe = Recipe.new()
+      allow(recipe).to receive(:total_grain_weight) {9.5}
+      expect((recipe.original_gravity).round(3)).to eq(1.053)
+    end
+  end
+
 end

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -15,6 +15,8 @@ describe Recipe do
     it { expect(@recipe).to validate_presence_of(:user_id) }
     it { expect(@recipe).to validate_presence_of(:grains).with_message(/must include name and weight of at least one grain/) }
     it { expect(@recipe).to validate_presence_of(:hops).with_message(/must include name and weight of at least one hop/) }
+    it { expect(@recipe.total_grain_weight).to_not be_nil }
+    it { expect(@recipe.batch_size).to_not be_nil }
   end
 
 end


### PR DESCRIPTION
Original gravity is a measurement that refers to the [specific gravity](http://en.wikipedia.org/wiki/Gravity_%28alcoholic_beverage%29) of the unfermented liquid (i.e., before the sugars are converted to alcohol by the yeast). The specific gravity is a measurement of density that corresponds to the amount of sugar in the liquid.

Basic beer brewing process:
1) Convert the starches in the grains to simple sugars (with water; this is called the "mash")
2) Extract the sugars from the mash (by separating the grains from the liquid and rinsing them with more water; the resulting liquid is called "wort")
3) Boiling the wort with hops
4) taking a specific gravity measurement ("original gravity")
5) adding yeast and allowing to ferment
6) taking periodic specific gravity measurements until the gravity is stable (i.e., the liquid is no longer fermenting; this is called the "final gravity")

Since the amount of alcohol in the resulting beer is a function of original gravity minus final gravity, having an estimate of the original gravity (e.g., the calculation in this PR) is helpful. It may not be exactly the same as the one that is measured on the brew day, but the estimate helps to give the brewer an idea of what the beer will be like.

I used the formula I had in my spreadsheet:
`(((37 * brewhouse_efficiency) / (batch_size / total_grain_weight)) + 1000) / 1000`

The standard batch size for home brewers in the US is 5 gallons, and a normal-ish brewhouse efficiency (i.e., how efficient your home brewing setup is at extracting sugars from the grains) is 75%.

I plan to make `batch_size` an attribute of the `recipe` model (sometime soon), and `brewhouse efficiency` an attribute of a `brewhouse` model (probably much later).

Let me know what you think!
