### PR TITLE
added yeast model and feature specs

### DIFF
--- a/spec/features/user_creates_recipes_spec.rb
+++ b/spec/features/user_creates_recipes_spec.rb
@@ -7,7 +7,8 @@ feature "User creates recipe", :type => :feature do
     sign_in(user)
     visit new_recipe_path
     fill_in "Style", with: "Stout"
-    fill_in "Yeast", with: "Nottingham"
+    fill_in "Yeast name", with: "Nottingham"
+    fill_in "Yeast attenuation", with: "78"
     fill_in "Summary", with: "A very dark stout"
     fill_in "Notes", with: "Brew very carefully..."
   end
@@ -27,6 +28,7 @@ feature "User creates recipe", :type => :feature do
     expect(current_path).to eq recipe_path(Recipe.first)
     expect(page).to have_content("Black Stout")
     expect(page).to have_content("Nottingham")
+    expect(page).to have_content("78")
     expect(page).to have_content("2-row")
     expect(page).to have_content("10")
     expect(page).to have_content("Crystal 40L")

--- a/spec/models/yeast_spec.rb
+++ b/spec/models/yeast_spec.rb
@@ -1,0 +1,13 @@
+require 'rails_helper'
+
+describe Yeast do
+  
+  before do
+    @yeasr = create(:yeast)
+  end
+
+  context "associations" do
+    it { expect(@yeast).to belong_to(:recipe) }
+  end
+
+end


### PR DESCRIPTION
I want to replace the yeast attribute with a yeast model, which would `belong_to` `recipe` (and recipe would `have_many` `yeasts`)

The yeast model would have these attributes:
1) `id`
2) `recipe_id` (foreign key)
3) `name`
4) `attenuation` (an estimate of how much sugar this strain of yeast will convert to alcohol, e.g., "78%". [more info](http://www.howtobrew.com/section1/chapter6-1.html))

I'll probably want to add a `temperature` attribute (the temperature at which this strain of yeast ferments best), but could do this at a later time.

In the case that I already had a bunch of users that had saved recipes, I assume that I'd want to preserve the already existing `yeast` attribute of the `recipe` model (which only stores the yeast name), and copy that to the `name` attribute of the new `yeast` model. I assume that I'd want to preserve the associated recipe by referencing that in the new table. I'm kind of stuck on how to do this (or even if this is what I should be doing); maybe we should discuss it in our next meeting?
