### PR TITLE
Fg calc

### DIFF
--- a/app/helpers/recipes_helper.rb
+++ b/app/helpers/recipes_helper.rb
@@ -1,2 +1,5 @@
 module RecipesHelper
+  def format_gravity(gravity)
+    '%.3f' % gravity
+  end
 end

--- a/app/models/recipe.rb
+++ b/app/models/recipe.rb
@@ -42,6 +42,18 @@ class Recipe < ActiveRecord::Base
     (((37 * brewhouse_efficiency) / (batch_size / total_grain_weight)) + 1000) / 1000
   end
 
+  def avg_attenuation
+    if yeasts.first
+      yeasts.average(:attenuation) / 100
+    else
+      0
+    end
+  end
+
+  def final_gravity
+    avg_attenuation + original_gravity + (-(original_gravity * avg_attenuation))
+  end
+
   def total_grain_weight
     grains.sum(:weight)
   end

--- a/app/models/yeast.rb
+++ b/app/models/yeast.rb
@@ -3,12 +3,4 @@ class Yeast < ActiveRecord::Base
 
   validates_presence_of :name
   validates_numericality_of :attenuation
-
-  before_save :convert_attentuation_percentage
-
-  private
-
-  def convert_attentuation_percentage
-    self.attenuation = attenuation.to_f/100.to_f
-  end 
 end

--- a/app/views/recipes/show.html.haml
+++ b/app/views/recipes/show.html.haml
@@ -13,7 +13,9 @@
         %td #{@recipe.batch_size} gal.
       %tr
         %td Original Gravity
-        %td #{'%.3f' % @recipe.original_gravity}
+        %td #{format_gravity(@recipe.original_gravity)}
+      - if @recipe.yeasts.first
+        %tr Final Gravity: #{format_gravity(@recipe.final_gravity)}
 
     %h4 Yeast
     %table.table.table-striped
@@ -21,7 +23,7 @@
         %tr
           %td= yeast.name
           %td
-            #{yeast.attenuation*100} %
+            #{yeast.attenuation} %
 
     %h4 Grains
     %table.table.table-striped

--- a/spec/features/user_creates_recipes_spec.rb
+++ b/spec/features/user_creates_recipes_spec.rb
@@ -47,9 +47,34 @@ feature "User creates recipe", js: true, :type => :feature do
     expect(page).to have_content("A very dark stout")
     expect(page).to have_content("Brew very carefully...")
     expect(page).to have_content("1.065")
+    expect(page).to have_content("Final Gravity")
+    expect(page).to have_content("1.014")
     expect(page).to have_content("Recipe saved.")
     expect(page).to have_content("5.25 gal.")
     expect(page).to have_content("60")
+  end
+
+  scenario "successfully, without yeast" do
+    fill_in "Enter a yeast name", with: ""
+    fill_in "Enter the yeast's average attenuation", with: ""
+
+    fill_in "Name", with: "Black Stout"
+    fill_in "Grain 1 name", with: "2-row"
+    fill_in "Grain 1 weight", with: "10"
+    click_button "Add grain"
+    fill_in "Grain 2 name", with: "Crystal 40L"
+    fill_in "Grain 2 weight", with: "2.25" 
+    fill_in "Hop 1 name", with: "Cascade"
+    fill_in "Hop 1 weight", with: "1.5"
+    fill_in "Hop 1 boil time", with: "30"
+    fill_in "Batch size", with: "5.25"
+
+    click_button "Save Recipe"
+
+    expect(Recipe.count).to eq(1)
+    expect(current_path).to eq recipe_path(Recipe.first)
+    expect(page).to_not have_content("1.014")
+    expect(page).to_not have_content("Final Gravity")
   end
 
   scenario "unsuccessfully, without required fields" do 

--- a/spec/models/recipe_spec.rb
+++ b/spec/models/recipe_spec.rb
@@ -30,6 +30,16 @@ describe Recipe do
     end
   end
 
+  context "#final_gravity" do
+
+    it "should calculate the final gravity" do
+      recipe = Recipe.new()
+      allow(recipe).to receive(:original_gravity) {1.069}
+      allow(recipe).to receive(:avg_attenuation) {0.755}
+      expect((recipe.final_gravity).round(3)).to eq(1.017)
+    end
+  end
+
   context "#total_grain_weight" do
     it "should calculate the total grain weight" do
       recipe = create(:recipe)
@@ -39,6 +49,18 @@ describe Recipe do
       recipe.save
 
       expect(recipe.total_grain_weight).to eq(12.5)
+    end
+  end
+
+  context "#avg_attenuation" do
+    it "should calculate average attenuation of yeasts" do
+      recipe = create(:recipe)
+      recipe.yeasts.destroy_all
+      recipe.yeasts.build(name: "Windsor", attenuation: 75.5)
+      recipe.yeasts.build(name: "Nottingham", attenuation: 68)
+      recipe.save
+
+      expect(recipe.avg_attenuation * 100).to eq(71.75)
     end
   end
 


### PR DESCRIPTION
Calculation for Final Gravity estimate (the amount of unfermented sugars left in the beer after it's fully fermented, i.e., the yeast have processed all of the sugars that they can). 

I removed the bit from the yeast model that was converting the form percentage (e.g., "75%") to a decimal percentage (e.g., "0.75"), as the conversion between the form and model was causing issues in recipe#edit and #show. I think it's cleaner to just convert it in the recipe model before it's used for calculations.
